### PR TITLE
fix: changes to hl_group_value and fixed missmatch between all and any

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Example using lazy.nvim
 
 ```lua
 {
-  'FlexxField/bionic-reading.nvim',
+  'FluxxField/bionic-reading.nvim',
   config = function()
     require('bionic-reading').setup({
       -- determines if the file types below will be
@@ -124,19 +124,16 @@ Example using lazy.nvim
       -- the node types you would like to target
       -- using treesitter
       file_types = {
-        ["text"] = {
-            "any", -- highlight any node
-        },
+        ["text"] = "any" -- highlight any node
         -- EX: only highlights comments in lua files
         ["lua"] = {
             "comment",
         },
       },
-      -- the highlighting styles applied
-      -- IMPORTANT - if link is present, no other
-      -- styles are applied
+      -- the highlighting styles applied as val to nvim_set_hl()
+      -- Please see :help nvim_set_hl() to see vals that can be passed
       hl_group_value = {
-        link = "Bold",
+        bold = true
       },
       -- Flag used to control if the user is prompted
       -- if BRToggle is called on a file type that is not

--- a/lua/bionic-reading/config.lua
+++ b/lua/bionic-reading/config.lua
@@ -14,9 +14,9 @@ local Config = {}
 local defaults = {
 	auto_highlight = true,
 	file_types = {
-		['text'] = 'all',
-		['lua'] = {
-			'comment',
+		["text"] = "any",
+		["lua"] = {
+			"comment",
 		},
 	},
 	hl_group_value = {
@@ -45,7 +45,7 @@ function Config._setup(opts)
 
 	vim.validate({
 		auto_highlight = { Config.opts.auto_highlight, "boolean" },
-		file_types = { Config.opts.file_types, {"table", "string"} },
+		file_types = { Config.opts.file_types, { "table", "string" } },
 		hl_group_value = { Config.opts.hl_group_value, "table" },
 		prompt_user = { Config.opts.prompt_user, "boolean" },
 		treesitter = { Config.opts.treesitter, "boolean" },

--- a/lua/bionic-reading/config.lua
+++ b/lua/bionic-reading/config.lua
@@ -14,15 +14,13 @@ local Config = {}
 local defaults = {
 	auto_highlight = true,
 	file_types = {
-		['text'] = {
-			'all'
-		},
+		['text'] = 'all',
 		['lua'] = {
 			'comment',
 		},
 	},
 	hl_group_value = {
-		link = "Bold",
+		bold = true,
 	},
 	prompt_user = true,
 	treesitter = true,
@@ -47,7 +45,7 @@ function Config._setup(opts)
 
 	vim.validate({
 		auto_highlight = { Config.opts.auto_highlight, "boolean" },
-		file_types = { Config.opts.file_types, "table" },
+		file_types = { Config.opts.file_types, {"table", "string"} },
 		hl_group_value = { Config.opts.hl_group_value, "table" },
 		prompt_user = { Config.opts.prompt_user, "boolean" },
 		treesitter = { Config.opts.treesitter, "boolean" },

--- a/lua/bionic-reading/highlight.lua
+++ b/lua/bionic-reading/highlight.lua
@@ -70,11 +70,18 @@ local function _treesitter_highlight(bufnr, line_start, line_end)
 		end
 	end
 
-	Utils.navigate_tree(root, function(node)
-		local config_node_types = Config.opts.file_types[vim.bo.filetype]
+	local filetype_node_types = Config.opts.file_types[vim.bo.filetype]
 
-		for _, node_type in ipairs(config_node_types) do
-			if node_type == 'all' or node_type == node:type() then
+	-- Early return, if node_type is 'any' then highlight to line_end
+	if type(filetype_node_types) == 'string' and filetype_node_types == 'any' then
+		_apply_highlighting(bufnr, line_start, line_end);
+
+		return true
+	end
+
+	Utils.navigate_tree(root, function(node)
+		for _, node_type in ipairs(filetype_node_types) do
+			if node_type == 'any' or node_type == node:type() then
 				local row_start = node:range()
 
 				_apply_highlighting(bufnr, row_start, row_start + 1)


### PR DESCRIPTION
- Fixed misspelled username in README. Fixes #63 
- Config incorrectly had 'all' instead of 'any'. If statement was checking for 'any' for 'any node'. Took the time to refactor and return any if filetype is 'any' then just highlight whole file instead of traversing the node tree. Fixes #64 
- Changed hl_group_value for link to bold. That way we dont have to worry about linking to a HL that has been cleared. Fixes #64 